### PR TITLE
Ensure Kate remembers her own messages

### DIFF
--- a/kate/memory.py
+++ b/kate/memory.py
@@ -17,10 +17,20 @@ def has_seen_message(message_id):
 def mark_message_seen(message_id):
     seen_messages.add(message_id)
 
-def update_memory(message):
-    """Store a Discord message in short term memory with some randomness."""
-    # Random chance to skip memory storage entirely
-    if random.random() > memory_storage_chance:
+def update_memory(message, force_store=False):
+    """Store a Discord message in short term memory with some randomness.
+
+    Parameters
+    ----------
+    message : discord.Message
+        The Discord message object to store.
+    force_store : bool, optional
+        If True, bypasses the random chance check and always stores the
+        message. Defaults to ``False``.
+    """
+
+    # Random chance to skip memory storage entirely unless forced
+    if not force_store and random.random() > memory_storage_chance:
         print(f"[{datetime.now().isoformat()}] Skipped memory storage for message: {message.id}")
         return
 

--- a/main.py
+++ b/main.py
@@ -378,7 +378,8 @@ async def on_message(message):
             mark_message_seen(content_fingerprint)
             
             # Now we can safely add it to memory
-            update_memory(message)
+            # Force storing Kate's own messages so she can remember them later
+            update_memory(message, force_store=True)
             return
             
         if has_seen_message(message.id) or has_seen_message(content_fingerprint):


### PR DESCRIPTION
## Summary
- store Kate's outgoing messages without random skipping
- add a `force_store` option to `update_memory`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684924aef0ec8322ad90a922ba316b1e